### PR TITLE
os/kernel: Fix os_sched_sleep when task switch is locked

### DIFF
--- a/hw/mcu/nordic/nrf5340/tfm/include/tfm/tfm.h
+++ b/hw/mcu/nordic/nrf5340/tfm/include/tfm/tfm.h
@@ -53,3 +53,17 @@ int SECURE_CALL tfm_uicr_otp_read(uint8_t n, uint32_t *ret);
  *         TFM_ERR_ACCESS_DENIED - when non-secure code is not allowed to change pin's MCU
  */
 int SECURE_CALL tfm_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu_sel);
+
+/**
+ * Function to set or read device protection status
+ *
+ * When variable pointer is non-NULL and variable is not 0 selected protection is activated.
+ * When variable pointer is non-NULL but is set to 0 variable is updated with current
+ * protection status.
+ *
+ * @param approtect - address of variable to set/read approtect status
+ * @param secure_approtect - address of variable to set/read secure_approtect status
+ * @param erase_protect -  - address of variable to set/read erase-all protection status
+ * @return 0 on success
+ */
+int SECURE_CALL tfm_uicr_protect_device(uint8_t *approtect, uint8_t *secure_approtect, uint8_t *erase_protect);

--- a/hw/mcu/nordic/nrf5340/tfm/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/tfm/pkg.yml
@@ -35,3 +35,4 @@ pkg.cflags.(!BOOT_LOADER && !MCU_APP_SECURE):
 pkg.lflags.(MCU_APP_SECURE && TFM_EXPORT_NSC):
     - -utfm_uicr_otp_read
     - -utfm_gpio_pin_mcu_select
+    - -utfm_uicr_protect_device

--- a/hw/mcu/nordic/nrf5340/tfm/src/tfm.c
+++ b/hw/mcu/nordic/nrf5340/tfm/src/tfm.c
@@ -38,6 +38,33 @@ tfm_uicr_otp_read(uint8_t n, uint32_t *ret)
 }
 
 int SECURE_CALL
+tfm_uicr_protect_device(uint8_t *approtect, uint8_t *secure_approtect, uint8_t *erase_protect)
+{
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+    if (approtect) {
+        if (*approtect != 0 && NRF_UICR_S->APPROTECT == 0x50FA50FA) {
+            NRF_UICR_S->APPROTECT = 0;
+        }
+        *approtect = NRF_UICR_S->APPROTECT == 0;
+    }
+    if (secure_approtect) {
+        if (*secure_approtect != 0 && NRF_UICR_S->SECUREAPPROTECT == 0x50FA50FA) {
+            NRF_UICR_S->SECUREAPPROTECT = 0;
+        }
+        *secure_approtect = NRF_UICR_S->SECUREAPPROTECT == 0;
+    }
+    if (erase_protect) {
+        if (*erase_protect != 0 && NRF_UICR_S->ERASEPROTECT == 0xFFFFFFFF) {
+            NRF_UICR_S->ERASEPROTECT = 0;
+        }
+        *erase_protect = NRF_UICR_S->ERASEPROTECT == 0;
+    }
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+
+    return 0;
+}
+
+int SECURE_CALL
 tfm_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu_sel)
 {
     int err = 0;

--- a/kernel/os/src/os_sched.c
+++ b/kernel/os/src/os_sched.c
@@ -180,6 +180,9 @@ os_sched_sleep(struct os_task *t, os_time_t nticks)
 {
     struct os_task *entry;
 
+    if (os_sched_lock_count) {
+        return 0;
+    }
     entry = NULL;
 
     TAILQ_REMOVE(&g_os_run_list, t, t_os_list);


### PR DESCRIPTION
When os_sched_sleep() was called from task that previously
disabled scheduler (using os_sched_suspend()) current
task was put in sleep queue and continue to execute while
not being marked as ready.
If task called os_sched_sleep() again g_os_sleep_list and
g_os_run_list get mixed resulting in idle task being active
all the time.

Now os_sched_sleep() does not modify task list when scheduling
is locked. It means that os_delay() will not not put task to
sleep and will exit immediately.