### PR TITLE
tinyusb: Fix CFG_TUSB_OS for custom bootlader builds

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -44,10 +44,10 @@ extern "C" {
 
 #define CFG_TUSB_RHPORT0_MODE       ((OPT_MODE_DEVICE) | (CFG_TUSB_RHPORT0_SPEED))
 
-#if MYNEWT_VAL(BOOT_LOADER)
-#define CFG_TUSB_OS                 OPT_OS_NONE
-#else
+#if MYNEWT_VAL(OS_SCHEDULING)
 #define CFG_TUSB_OS                 OPT_OS_MYNEWT
+#else
+#define CFG_TUSB_OS                 OPT_OS_NONE
 #endif
 #define CFG_TUSB_DEBUG              MYNEWT_VAL(CFG_TUSB_DEBUG)
 


### PR DESCRIPTION
TinyUSB build with mcuboot allows to have DFU or MSC for firmware update.
In such case there is no mynewt scheduling and USB task takes over CPU.

However for custom builds (without mcuboot) mynewt can run normal os
scheduling while having BOOT_LOADER set to 1 for linking into boot
area.

Now std_descriptors tusb_config.h checks for OS_SCHEDULING instead
of BOOT_LOADER to decided if TinyUSB should run in mynewt os mode
or bare metal one.